### PR TITLE
fix: mismatched type and format in reward credits

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5242,8 +5242,8 @@
                   "description": "RGB value as an int assigned to this reward"
                },
                "credits": {
-                  "type": "number",
-                  "format": "int",
+                  "type": "integer",
+                  "format": "int32",
                   "description": "Amount of credits awarded"
                },
                "asString": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3337,8 +3337,8 @@ components:
           type: number
           description: RGB value as an int assigned to this reward
         credits:
-          type: number
-          format: int
+          type: integer
+          format: int32
           description: Amount of credits awarded
         asString:
           minLength: 1

--- a/spec/components/schemas/reward.yaml
+++ b/spec/components/schemas/reward.yaml
@@ -32,8 +32,8 @@ properties:
     type: number
     description: RGB value as an int assigned to this reward
   credits:
-    type: number
-    format: int
+    type: integer
+    format: int32
     description: Amount of credits awarded
   asString:
     minLength: 1


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closed \#15

---

### Reproduction steps
[`oapi-codegen`](https://github.com/deepmap/oapi-codegen) doesn't accept original `openapi.yaml` with command `oapi-codegen openapi.yaml > wfstat.go`:
```
error generating code: error generating type definitions: error generating Go types for component schemas: error converting Schema reward to Go type: error generating Go schema for property 'credits': error resolving primitive type: invalid number format: int
```

---

### Evidence/screenshot/link to line
According to [OpenAPI Specification v3.0.3](https://spec.openapis.org/oas/v3.0.3#data-types), `int` is not a correct format for `number` type.
It should be `integer` type and `int32`/`int64` format.

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
