### PR TITLE
add missing description field

### DIFF
--- a/openapi/components/schemas/mission.yaml
+++ b/openapi/components/schemas/mission.yaml
@@ -1,6 +1,7 @@
 type: object
 required:
   - archwingRequired
+  - description
   - faction
   - maxEnemyLevel
   - maxWaveNum

--- a/openapi/components/schemas/mission.yaml
+++ b/openapi/components/schemas/mission.yaml
@@ -62,3 +62,6 @@ properties:
     description: Affectors for this mission
     items:
       type: string
+  description:
+    type: string
+    description: Description of the mission


### PR DESCRIPTION
### What did you fix? 
added mission description field which was missing in spec.

---

### Reproduction steps
1. fetch https://api.warframestat.us/pc
2. select `alerts[0].mission` => has field `description`
3. add spec in [components/schemas/mission.yaml](https://github.com/WFCD/api-spec/compare/master...peanutbother:patch-1#diff-3e72bf6d23baea5ba7edb15aaded188a05a8d408fe3d36648d5ad52be383685f)
---

### Evidence/screenshot/link to line
![image](https://user-images.githubusercontent.com/6437182/165641800-fd4117c3-6f56-47b1-b911-62598c25194e.png)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement/Docs**
