### PR TITLE
fix: add missing "active" field

### DIFF
--- a/openapi/components/schemas/alert.yaml
+++ b/openapi/components/schemas/alert.yaml
@@ -2,6 +2,8 @@ type: object
 properties:
   mission:
     $ref: ./mission.yaml
+  active:
+    type: boolean
   expired:
     type: boolean
   eta:
@@ -24,6 +26,7 @@ properties:
       $ref: ./rewardType.yaml
 required:
   - activation
+  - active
   - eta
   - expired
   - expiry


### PR DESCRIPTION
### What did you fix? 
added `active` field which was missing in spec.

---

### Reproduction steps
1. fetch https://api.warframestat.us/pc
2. select `alerts[0]` => has field `active`
3. add spec in [components/schemas/alert.yaml](https://github.com/WFCD/api-spec/compare/master...peanutbother:patch-4#diff-dbb283e14766e2ec6af910f3dda9afdf74b3ca82b79f875e09ad8a9e41de9330)
---

### Evidence/screenshot/link to line
![image](https://user-images.githubusercontent.com/6437182/165641800-fd4117c3-6f56-47b1-b911-62598c25194e.png)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement/Docs**
