### PR TITLE
docs: Changed cambionCycle's "active" to "state"

### DIFF
--- a/openapi/components/schemas/cambionCycle.yaml
+++ b/openapi/components/schemas/cambionCycle.yaml
@@ -12,7 +12,7 @@ properties:
     $ref: ./timestamp.yaml
   activation:
     $ref: ./timestamp.yaml
-  active:
+  state:
     type: string
     enum:
       - vome

--- a/openapi/components/schemas/cambionCycle.yaml
+++ b/openapi/components/schemas/cambionCycle.yaml
@@ -2,7 +2,7 @@ required:
   - expiry
   - activation
   - id
-  - active
+  - state
 type: object
 properties:
   id:
@@ -13,6 +13,12 @@ properties:
   activation:
     $ref: ./timestamp.yaml
   state:
+    type: string
+    enum:
+      - vome
+      - fass
+  active:
+    deprecated: true
     type: string
     enum:
       - vome


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Changed cambionCycle "active" key to "state" so it's continuous with cetusCycle, earthCycle and vallisCycle.

Tobi asked me to make a PR [here](https://github.com/WFCD/warframe-worldstate-parser/issues/426)
Still trying to get the worldstate parser working so I can make changes there, it's giving me a lot of pain and I hate npm.
(This probably shouldn't be merged until worldstate-parser is changed aswell.)

### Evidence/screenshot/link to line

See [line 15](https://github.com/WFCD/api-spec/compare/master...Neppkun:api-spec:master?expand=1#diff-968ac4ac11fdbcd1a9ebab69f1496a09321567398f750c6d41bca521d3d36f48R15)

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes(?)**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Feature Request**
