### PR TITLE
docs: add even tag

### DIFF
--- a/openapi/components/schemas/event.yaml
+++ b/openapi/components/schemas/event.yaml
@@ -151,4 +151,4 @@ allOf:
             description: Next alternate activation. Use unknown.
       tag:
         type: string
-        description: Event's tag
+        description: A unique identifier or category label for the event, used to group or filter related events.

--- a/openapi/components/schemas/event.yaml
+++ b/openapi/components/schemas/event.yaml
@@ -149,3 +149,6 @@ allOf:
             type: string
             format: date-time
             description: Next alternate activation. Use unknown.
+      tag:
+        type: string
+        description: Event's tag

--- a/openapi/paths/profile@{username}.yaml
+++ b/openapi/paths/profile@{username}.yaml
@@ -3,7 +3,9 @@ get:
   tags:
     - Profile
   summary: Get player profile
-  description: Get player profile from available GDPR data.
+  description: >-
+    Get the player profile from the available GDPR data. 
+    DE now has the profile endpoint behind authentication, and all requests will timeout.
   parameters:
     - $ref: ../components/parameters/username.yaml
   responses:

--- a/openapi/paths/profile@{username}@stats.yaml
+++ b/openapi/paths/profile@{username}@stats.yaml
@@ -3,7 +3,9 @@ get:
   tags:
     - Profile
   summary: Get player stats
-  description: Get player stats from available GDPR data.
+  description: >- 
+    Get the player profile from the available GDPR data. 
+    DE now has the profile endpoint behind authentication, and all requests will timeout.
   parameters:
     - $ref: ../components/parameters/username.yaml
   responses:

--- a/openapi/paths/{platform}@deepArchimedea.yaml
+++ b/openapi/paths/{platform}@deepArchimedea.yaml
@@ -4,7 +4,8 @@ get:
     - Worldstate
   summary: Get current Deep Archimedea information
   description: >-
-    Data on current Deep Archimedea missions, deviations, risk variables, and personal modifiers
+    Data on current Deep Archimedea missions, deviations, risk variables, 
+    and personal modifiers may not be up to date and, in some cases, may be omitted from the world state.
   parameters:
     - $ref: ../components/parameters/language.yaml
     - $ref: ../components/parameters/language-query.yaml


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->

- add docs for `Event.tag`
- update `DeepArchimedea` for clarity on why it may be omitted from the response
- update `Profile` with the explaining why it's timing out

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Docs**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced event tagging to enhance the classification of events.
- **Documentation**
	- Refined profile endpoint descriptions to clearly state authentication requirements and timeout behaviors.
	- Updated player stats endpoint description for clarity on data retrieval and authentication.
	- Added disclaimer to Deep Archimedea data availability regarding potential outdated information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->